### PR TITLE
Lowered the minimum CMake version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.15)
 project(cleric C)
 
 # Set the C language standard to C99 for all targets


### PR DESCRIPTION
Setting minimum CMake version to 3.31 seems a bit restrictive, since no such modern feature is used